### PR TITLE
FIX: Buggy SilverStripe\\View\\SSViewer parsing

### DIFF
--- a/src/theming/themeCascade.js
+++ b/src/theming/themeCascade.js
@@ -3,7 +3,8 @@ const isset = require('isset')
 module.exports = (config) => {
   if (
     isset(config) &&
-    isset(config['SilverStripe\\View\\SSViewer'])
+    isset(config['SilverStripe\\View\\SSViewer']) &&
+    isset(config['SilverStripe\\View\\SSViewer'].themes)
   ) {
     return config['SilverStripe\\View\\SSViewer'].themes.filter(themeName => {
       // Remove any variable theme


### PR DESCRIPTION
Themes isn't defined here
```
SilverStripe\View\SSViewer:
  source_file_comments: false
```
```
2023-02-03 16:34:34.910 [error] Activating extension adrianhumphreys.silverstripe failed due to an error:
2023-02-03 16:34:34.910 [error] TypeError: Cannot read properties of undefined (reading 'filter')
    at module.exports../node_modules/.pnpm/silverstripe-sanchez@2.0.2/node_modules/silverstripe-sanchez/src/theming/themeCascade.js.module.exports (/home/tony/Downloads/Software/vscode-silverstripe/node_modules/.pnpm/silverstripe-sanchez@2.0.2/node_modules/silverstripe-sanchez/src/theming/themeCascade.js:9:1)
```