### PR TITLE
FIX: Custom snippet file read

### DIFF
--- a/src/init/readSanchez.js
+++ b/src/init/readSanchez.js
@@ -15,12 +15,12 @@ module.exports = (paths = []) => {
   // We accept cson, json or yml formats
   for (const filepath in paths) {
     if (filepath in paths) {
-      if (fs.existsSync(filepath)) {
+      if (fs.existsSync(paths[filepath])) {
         data = merge(
           data,
           parse(
             fs.readFileSync(
-              filepath,
+              paths[filepath],
               {
                 encoding: 'utf-8'
               }


### PR DESCRIPTION
The loop that was meant to detect the .silverstripe_sanchez files was only pulling the array key, rather than the actual filepath value. This has been updated from `filepath` to `paths[filepath]`, which now correctly detects and reads the files.